### PR TITLE
Support for other boards and shields

### DIFF
--- a/NTPClient.h
+++ b/NTPClient.h
@@ -2,15 +2,14 @@
 
 #include "Arduino.h"
 
-#include <ESP8266WiFi.h>
-#include <WiFiUdp.h>
+#include <Udp.h>
 
 #define SEVENZYYEARS 2208988800UL
 #define NTP_PACKET_SIZE 48
 
 class NTPClient {
   private:
-    WiFiUDP       _udp;
+    UDP*          _udp;
 
     const char*   _poolServerName = "time.nist.gov"; // Default time server
     int           _port           = 1337;
@@ -23,14 +22,14 @@ class NTPClient {
 
     byte          _packetBuffer[NTP_PACKET_SIZE];
 
-    void          sendNTPPacket(IPAddress _timeServerIP);
+    void          sendNTPPacket();
 
   public:
-    NTPClient();
-    NTPClient(int timeOffset);
-    NTPClient(const char* poolServerName);
-    NTPClient(const char* poolServerName, int timeOffset);
-    NTPClient(const char* poolServerName, int timeOffset, int updateInterval);
+    NTPClient(UDP& udp);
+    NTPClient(UDP& udp, int timeOffset);
+    NTPClient(UDP& udp, const char* poolServerName);
+    NTPClient(UDP& udp, const char* poolServerName, int timeOffset);
+    NTPClient(UDP& udp, const char* poolServerName, int timeOffset, int updateInterval);
 
     /**
      * This should be called in the main loop of your application. By default an update from the NTP Server is only

--- a/README.md
+++ b/README.md
@@ -4,10 +4,16 @@ Connect to a NTP server, here is how:
 
 ```cpp
 #include <NTPClient.h>
+// change next line to use with another board/shield
 #include <ESP8266WiFi.h>
+//#include <WiFi.h> // for WiFi shield
+//#include <WiFi101.h> // for WiFi 101 shield or MKR1000
+#include <WiFiUdp.h>
 
 const char *ssid     = "<SSID>";
 const char *password = "<PASSWORD>";
+
+WiFiUDP ntpUDP(ntpUDP);
 
 // By default 'time.nist.gov' is used.
 NTPClient timeClient;

--- a/examples/Advanced/Advanced.ino
+++ b/examples/Advanced/Advanced.ino
@@ -1,12 +1,18 @@
 #include <NTPClient.h>
+// change next line to use with another board/shield
 #include <ESP8266WiFi.h>
+//#include <WiFi.h> // for WiFi shield
+//#include <WiFi101.h> // for WiFi 101 shield or MKR1000
+#include <WiFiUdp.h>
 
 const char *ssid     = "<SSID>";
 const char *password = "<PASSWORD>";
 
+WiFiUDP ntpUDP;
+
 // You can specify the time server pool and the offset, (in seconds)
 // additionaly you can specify the update interval (in milliseconds).
-NTPClient timeClient("europe.pool.ntp.org", 3600, 60000);
+NTPClient timeClient(ntpUDP, "europe.pool.ntp.org", 3600, 60000);
 
 void setup(){
   Serial.begin(115200);

--- a/examples/Basic/Basic.ino
+++ b/examples/Basic/Basic.ino
@@ -1,12 +1,15 @@
 #include <NTPClient.h>
+// change next line to use with another board/shield
 #include <ESP8266WiFi.h>
+//#include <WiFi.h> // for WiFi shield
+//#include <WiFi101.h> // for WiFi 101 shield or MKR1000
+#include <WiFiUdp.h>
 
 const char *ssid     = "<SSID>";
 const char *password = "<PASSWORD>";
 
-
-
-NTPClient timeClient;
+WiFiUDP ntpUDP;
+NTPClient timeClient(ntpUDP);
 
 void setup(){
   Serial.begin(115200);

--- a/library.properties
+++ b/library.properties
@@ -1,9 +1,9 @@
 name=NTPClient
-version=2.0.0
+version=3.0.0
 author=Fabrice Weinberg
 maintainer=Fabrice Weinberg <fabrice@weinberg.me>
 sentence=An NTPClient to connect to a time server
 paragraph=Get time from a NTP server and keep it in sync.
 category=Timing
 url=https://github.com/FWeinb/NTPClient
-architectures=esp8266
+architectures=*


### PR DESCRIPTION
This is a great library! With a few changes it could support running on non-ESP8266 boards as well. 

In this patch, I've added an UDP instance argument in constructor to support more architectures. This way other networking libraries like [Ethernet](https://github.com/arduino-libraries/Ethernet), [WiFi](https://github.com/arduino-libraries/WiFi), and [WiFi101](https://github.com/arduino-libraries/WiFi101)  can also be supported.

However, the tradeoffs are:

1. This is a breaking change to the API
2. Existing sketches that use this library require the following changes:
  * Add:  ```#include <WiFiUdp.h>```
  * Create ```WiFiUDP``` instance: ```WiFiUDP ntpUDP;```
  * Pass ```WiFiUDP``` instance to constructor: ```NTPClient timeClient(ntpUDP, ....);```

For Ethernet shield users:

1. ```#include <Ethernet.h>``` is needed instead of ```#include <ESP8266WiFi.h>```
2. ```#include <EthernetUdp.h>``` is needed instead of ```WiFiUdp.h```
2. Create ```EthernetUDP``` instance instead of ```WiFiUdp.h```

What do you think?