### PR TITLE
Add travis build test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,10 @@
+language: c
+sudo: false
+before_install:
+  - source <(curl -SLs https://raw.githubusercontent.com/adafruit/travis-ci-arduino/master/install.sh)
+script:
+  - build_platform esp8266
+notifications:
+  email:
+    on_success: change
+    on_failure: change


### PR DESCRIPTION
I think this library should be tested via [travis-ci-arduino](https://github.com/adafruit/travis-ci-arduino)
I just added esp8266 for now. We may need to add some examples for the other platforms and build only the valid example for each platform. 

@sandeepmistry 
Someone needs to enable this repo on travis. 