### PR TITLE
Added functions for changing the timeOffset and updateInterval later

### DIFF
--- a/NTPClient.cpp
+++ b/NTPClient.cpp
@@ -140,6 +140,14 @@ void NTPClient::end() {
   this->_udpSetup = false;
 }
 
+void NTPClient::setTimeOffset(int timeOffset) {
+  this->_timeOffset     = timeOffset;
+}
+
+void NTPClient::setUpdateInterval(int updateInterval) {
+  this->_updateInterval = updateInterval;
+}
+
 void NTPClient::sendNTPPacket() {
   // set all bytes in the buffer to 0
   memset(this->_packetBuffer, 0, NTP_PACKET_SIZE);
@@ -161,4 +169,3 @@ void NTPClient::sendNTPPacket() {
   this->_udp->write(this->_packetBuffer, NTP_PACKET_SIZE);
   this->_udp->endPacket();
 }
-

--- a/NTPClient.h
+++ b/NTPClient.h
@@ -64,6 +64,17 @@ class NTPClient {
     int getSeconds();
 
     /**
+     * Changes the time offset. Useful for changing timezones dynamically
+     */
+    void setTimeOffset(int timeOffset);
+
+    /**
+     * Set the update interval to another frequency. E.g. useful when the
+     * timeOffset should not be set in the constructor
+     */
+    void setUpdateInterval(int updateInterval);
+
+    /**
      * @return time formatted like `hh:mm:ss`
      */
     String getFormattedTime();

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# NTPClient 
+# NTPClient
 
 [![Build Status](https://travis-ci.org/arduino-libraries/NTPClient.svg?branch=master)](https://travis-ci.org/arduino-libraries/NTPClient)
 
@@ -17,12 +17,13 @@ const char *password = "<PASSWORD>";
 
 WiFiUDP ntpUDP;
 
-// By default 'time.nist.gov' is used.
+// By default 'time.nist.gov' is used with 60 seconds update interval and
+// no offset
 NTPClient timeClient(ntpUDP);
 
 // You can specify the time server pool and the offset, (in seconds)
 // additionaly you can specify the update interval (in milliseconds).
-// NTPClient timeClient("europe.pool.ntp.org", 3600, 60000);
+// NTPClient timeClient(ntpUDP, "europe.pool.ntp.org", 3600, 60000);
 
 void setup(){
   Serial.begin(11520);
@@ -38,9 +39,9 @@ void setup(){
 
 void loop() {
   timeClient.update();
-  
+
   Serial.println(timeClient.getFormattedTime());
-  
+
   delay(1000);
 }
 ```

--- a/examples/Advanced/Advanced.ino
+++ b/examples/Advanced/Advanced.ino
@@ -10,8 +10,9 @@ const char *password = "<PASSWORD>";
 
 WiFiUDP ntpUDP;
 
-// You can specify the time server pool and the offset, (in seconds)
-// additionaly you can specify the update interval (in milliseconds).
+// You can specify the time server pool and the offset (in seconds, can be
+// changed later with setTimeOffset() ). Additionaly you can specify the
+// update interval (in milliseconds, can be changed using setUpdateInterval() ).
 NTPClient timeClient(ntpUDP, "europe.pool.ntp.org", 3600, 60000);
 
 void setup(){


### PR DESCRIPTION
I added two functions:
```cpp
setTimeOffset(int timeOffset)
```

Allows you to set the offset at a later stage (e.g. upon timezone
changes or change from summertime to standard time)

```cpp
setUpdateInterval(int updateInterval)
```

Allows to set the interval at a later point. This was helpful when not
setting an offset at initialization and e.g. for other sync times during
special occasions.