### PR TITLE
Added support for server IPAddress argument to NTPClient

### DIFF
--- a/NTPClient.cpp
+++ b/NTPClient.cpp
@@ -35,6 +35,12 @@ NTPClient::NTPClient(UDP& udp, const char* poolServerName) {
   this->_poolServerName = poolServerName;
 }
 
+NTPClient::NTPClient(UDP& udp, IPAddress poolServerIP) {
+  this->_udp            = &udp;
+  this->_poolServerIP = poolServerIP;
+  this->_poolServerName = NULL;
+}
+
 NTPClient::NTPClient(UDP& udp, const char* poolServerName, int timeOffset) {
   this->_udp            = &udp;
   this->_timeOffset     = timeOffset;
@@ -165,7 +171,8 @@ void NTPClient::sendNTPPacket() {
 
   // all NTP fields have been given values, now
   // you can send a packet requesting a timestamp:
-  this->_udp->beginPacket(this->_poolServerName, 123); //NTP requests are to port 123
+  if (this->_poolServerName) this->_udp->beginPacket(this->_poolServerName, 123); // NTP requests are to port 123
+    else this->_udp->beginPacket(this->_poolServerIP, 123);
   this->_udp->write(this->_packetBuffer, NTP_PACKET_SIZE);
   this->_udp->endPacket();
 }

--- a/NTPClient.h
+++ b/NTPClient.h
@@ -14,6 +14,7 @@ class NTPClient {
     bool          _udpSetup       = false;
 
     const char*   _poolServerName = "time.nist.gov"; // Default time server
+    IPAddress     _poolServerIP;
     int           _port           = NTP_DEFAULT_LOCAL_PORT;
     int           _timeOffset     = 0;
 
@@ -30,6 +31,7 @@ class NTPClient {
     NTPClient(UDP& udp);
     NTPClient(UDP& udp, int timeOffset);
     NTPClient(UDP& udp, const char* poolServerName);
+    NTPClient(UDP& udp, IPAddress poolServerIP);
     NTPClient(UDP& udp, const char* poolServerName, int timeOffset);
     NTPClient(UDP& udp, const char* poolServerName, int timeOffset, int updateInterval);
 


### PR DESCRIPTION
Added option to connect to NTP server with binary poolServerIP argument, as alternative to string poolServerName. This takes slightly less memory, and is faster than doing a DNS lookup. If a string IP address was provided, it would still incur the overhead of being recognised as a numeric string, and converted to binary.

Fixes #31 