### PR TITLE
Set new poolServerName

### DIFF
--- a/NTPClient.cpp
+++ b/NTPClient.cpp
@@ -236,10 +236,10 @@ void NTPClient::sendNTPPacket() {
   this->_packetBuffer[2] = 6;     // Polling Interval
   this->_packetBuffer[3] = 0xEC;  // Peer Clock Precision
   // 8 bytes of zero for Root Delay & Root Dispersion
-  this->_packetBuffer[12]  = 49;
+  this->_packetBuffer[12]  = 0x49;
   this->_packetBuffer[13]  = 0x4E;
-  this->_packetBuffer[14]  = 49;
-  this->_packetBuffer[15]  = 52;
+  this->_packetBuffer[14]  = 0x49;
+  this->_packetBuffer[15]  = 0x52;
 
   // all NTP fields have been given values, now
   // you can send a packet requesting a timestamp:

--- a/NTPClient.cpp
+++ b/NTPClient.cpp
@@ -164,6 +164,33 @@ String NTPClient::getFormattedTime(unsigned long secs) {
   return hoursStr + ":" + minuteStr + ":" + secondStr;
 }
 
+// Based on https://github.com/PaulStoffregen/Time/blob/master/Time.cpp
+// currently assumes UTC timezone, instead of using this->_timeOffset
+String NTPClient::getFormattedDate(unsigned long secs) {
+  unsigned long rawTime = (secs ? secs : this->getEpochTime()) / 86400L;  // in days
+  unsigned long days = 0, year = 1970;
+  uint8_t month;
+  static const uint8_t monthDays[]={31,28,31,30,31,30,31,31,30,31,30,31};
+
+  while((days += (LEAP_YEAR(year) ? 366 : 365)) <= rawTime)
+    year++;
+  rawTime -= days - (LEAP_YEAR(year) ? 366 : 365); // now it is days in this year, starting at 0
+  days=0;
+  for (month=0; month<12; month++) {
+    uint8_t monthLength;
+    if (month==1) { // february
+      monthLength = LEAP_YEAR(year) ? 29 : 28;
+    } else {
+      monthLength = monthDays[month];
+    }
+    if (rawTime < monthLength) break;
+    rawTime -= monthLength;
+  }
+  String monthStr = ++month < 10 ? "0" + String(month) : String(month); // jan is month 1  
+  String dayStr = ++rawTime < 10 ? "0" + String(rawTime) : String(rawTime); // day of month  
+  return String(year) + "-" + monthStr + "-" + dayStr + "T" + this->getFormattedTime(secs ? secs : 0) + "Z";
+}
+
 void NTPClient::end() {
   this->_udp->stop();
 

--- a/NTPClient.cpp
+++ b/NTPClient.cpp
@@ -243,8 +243,7 @@ void NTPClient::sendNTPPacket() {
 
   // all NTP fields have been given values, now
   // you can send a packet requesting a timestamp:
-  if (this->_poolServerName) this->_udp->beginPacket(this->_poolServerName, 123); // NTP requests are to port 123
-  else this->_udp->beginPacket(this->_poolServerIP, 123);
+  this->_udp->beginPacket(this->_poolServerName, 123); //NTP requests are to port 123
   this->_udp->write(this->_packetBuffer, NTP_PACKET_SIZE);
   this->_udp->endPacket();
 }

--- a/NTPClient.cpp
+++ b/NTPClient.cpp
@@ -41,7 +41,7 @@ NTPClient::NTPClient(UDP& udp, const char* poolServerName, int timeOffset) {
   this->_poolServerName = poolServerName;
 }
 
-NTPClient::NTPClient(UDP& udp, const char* poolServerName, int timeOffset, int updateInterval) {
+NTPClient::NTPClient(UDP& udp, const char* poolServerName, int timeOffset, unsigned long updateInterval) {
   this->_udp            = &udp;
   this->_timeOffset     = timeOffset;
   this->_poolServerName = poolServerName;
@@ -174,7 +174,7 @@ void NTPClient::setTimeOffset(int timeOffset) {
   this->_timeOffset     = timeOffset;
 }
 
-void NTPClient::setUpdateInterval(int updateInterval) {
+void NTPClient::setUpdateInterval(unsigned long updateInterval) {
   this->_updateInterval = updateInterval;
 }
 

--- a/NTPClient.cpp
+++ b/NTPClient.cpp
@@ -60,6 +60,30 @@ void NTPClient::begin(int port) {
   this->_udpSetup = true;
 }
 
+bool NTPClient::isValid(byte * ntpPacket)
+{
+	//Perform a few validity checks on the packet
+	if((ntpPacket[0] & 0b11000000) == 0b11000000)		//Check for LI=UNSYNC
+		return false;
+		
+	if((ntpPacket[0] & 0b00111000) >> 3 < 0b100)		//Check for Version >= 4
+		return false;
+		
+	if((ntpPacket[0] & 0b00000111) != 0b100)			//Check for Mode == Server
+		return false;
+		
+	if((ntpPacket[1] < 1) || (ntpPacket[1] > 15))		//Check for valid Stratum
+		return false;
+
+	if(	ntpPacket[16] == 0 && ntpPacket[17] == 0 && 
+		ntpPacket[18] == 0 && ntpPacket[19] == 0 &&
+		ntpPacket[20] == 0 && ntpPacket[21] == 0 &&
+		ntpPacket[22] == 0 && ntpPacket[22] == 0)		//Check for ReferenceTimestamp != 0
+		return false;
+
+	return true;
+}
+
 bool NTPClient::forceUpdate() {
   #ifdef DEBUG_NTPClient
     Serial.println("Update from NTP Server");
@@ -73,13 +97,19 @@ bool NTPClient::forceUpdate() {
   do {
     delay ( 10 );
     cb = this->_udp->parsePacket();
+    
+    if(cb > 0)
+    {
+      this->_udp->read(this->_packetBuffer, NTP_PACKET_SIZE);
+      if(!this->isValid(this->_packetBuffer))
+        cb = 0;
+    }
+    
     if (timeout > 100) return false; // timeout after 1000 ms
     timeout++;
   } while (cb == 0);
 
   this->_lastUpdate = millis() - (10 * (timeout + 1)); // Account for delay in reading the time
-
-  this->_udp->read(this->_packetBuffer, NTP_PACKET_SIZE);
 
   unsigned long highWord = word(this->_packetBuffer[40], this->_packetBuffer[41]);
   unsigned long lowWord = word(this->_packetBuffer[42], this->_packetBuffer[43]);

--- a/NTPClient.cpp
+++ b/NTPClient.cpp
@@ -35,16 +35,37 @@ NTPClient::NTPClient(UDP& udp, const char* poolServerName) {
   this->_poolServerName = poolServerName;
 }
 
+NTPClient::NTPClient(UDP& udp, IPAddress poolServerIP) {
+  this->_udp            = &udp;
+  this->_poolServerIP = poolServerIP;
+  this->_poolServerName = NULL;
+}
+
 NTPClient::NTPClient(UDP& udp, const char* poolServerName, int timeOffset) {
   this->_udp            = &udp;
   this->_timeOffset     = timeOffset;
   this->_poolServerName = poolServerName;
 }
 
+NTPClient::NTPClient(UDP& udp, IPAddress poolServerIP,int timeOffset){
+  this->_udp            = &udp;
+  this->_timeOffset     = timeOffset;
+  this->_poolServerIP = poolServerIP;
+  this->_poolServerName = NULL;
+}
+
 NTPClient::NTPClient(UDP& udp, const char* poolServerName, int timeOffset, unsigned long updateInterval) {
   this->_udp            = &udp;
   this->_timeOffset     = timeOffset;
   this->_poolServerName = poolServerName;
+  this->_updateInterval = updateInterval;
+}
+
+NTPClient::NTPClient(UDP& udp, IPAddress poolServerIP, int timeOffset, unsigned long updateInterval) {
+  this->_udp            = &udp;
+  this->_timeOffset     = timeOffset; 
+  this->_poolServerIP = poolServerIP;
+  this->_poolServerName = NULL;
   this->_updateInterval = updateInterval;
 }
 

--- a/NTPClient.cpp
+++ b/NTPClient.cpp
@@ -35,37 +35,16 @@ NTPClient::NTPClient(UDP& udp, const char* poolServerName) {
   this->_poolServerName = poolServerName;
 }
 
-NTPClient::NTPClient(UDP& udp, IPAddress poolServerIP) {
-  this->_udp            = &udp;
-  this->_poolServerIP = poolServerIP;
-  this->_poolServerName = NULL;
-}
-
 NTPClient::NTPClient(UDP& udp, const char* poolServerName, int timeOffset) {
   this->_udp            = &udp;
   this->_timeOffset     = timeOffset;
   this->_poolServerName = poolServerName;
 }
 
-NTPClient::NTPClient(UDP& udp, IPAddress poolServerIP,int timeOffset){
-  this->_udp            = &udp;
-  this->_timeOffset     = timeOffset;
-  this->_poolServerIP = poolServerIP;
-  this->_poolServerName = NULL;
-}
-
 NTPClient::NTPClient(UDP& udp, const char* poolServerName, int timeOffset, unsigned long updateInterval) {
   this->_udp            = &udp;
   this->_timeOffset     = timeOffset;
   this->_poolServerName = poolServerName;
-  this->_updateInterval = updateInterval;
-}
-
-NTPClient::NTPClient(UDP& udp, IPAddress poolServerIP, int timeOffset, unsigned long updateInterval) {
-  this->_udp            = &udp;
-  this->_timeOffset     = timeOffset; 
-  this->_poolServerIP = poolServerIP;
-  this->_poolServerName = NULL;
   this->_updateInterval = updateInterval;
 }
 

--- a/NTPClient.cpp
+++ b/NTPClient.cpp
@@ -243,7 +243,8 @@ void NTPClient::sendNTPPacket() {
 
   // all NTP fields have been given values, now
   // you can send a packet requesting a timestamp:
-  this->_udp->beginPacket(this->_poolServerName, 123); //NTP requests are to port 123
+  if (this->_poolServerName) this->_udp->beginPacket(this->_poolServerName, 123); // NTP requests are to port 123
+  else this->_udp->beginPacket(this->_poolServerIP, 123);
   this->_udp->write(this->_packetBuffer, NTP_PACKET_SIZE);
   this->_udp->endPacket();
 }

--- a/NTPClient.cpp
+++ b/NTPClient.cpp
@@ -150,8 +150,8 @@ int NTPClient::getSeconds() {
   return (this->getEpochTime() % 60);
 }
 
-String NTPClient::getFormattedTime() {
-  unsigned long rawTime = this->getEpochTime();
+String NTPClient::getFormattedTime(unsigned long secs) {
+  unsigned long rawTime = secs ? secs : this->getEpochTime();
   unsigned long hours = (rawTime % 86400L) / 3600;
   String hoursStr = hours < 10 ? "0" + String(hours) : String(hours);
 
@@ -198,4 +198,8 @@ void NTPClient::sendNTPPacket() {
   this->_udp->beginPacket(this->_poolServerName, 123); //NTP requests are to port 123
   this->_udp->write(this->_packetBuffer, NTP_PACKET_SIZE);
   this->_udp->endPacket();
+}
+
+void NTPClient::setEpochTime(unsigned long secs) {
+  this->_currentEpoc = secs;
 }

--- a/NTPClient.h
+++ b/NTPClient.h
@@ -84,6 +84,12 @@ class NTPClient {
      * @return time in seconds since Jan. 1, 1970
      */
     unsigned long getEpochTime();
+  
+    /**
+    * @return secs argument (or 0 for current date) formatted to ISO 8601
+    * like `2004-02-12T15:19:21+00:00`
+    */
+    String getFormattedDate(unsigned long secs = 0);
 
     /**
      * Stops the underlying UDP client

--- a/NTPClient.h
+++ b/NTPClient.h
@@ -17,7 +17,7 @@ class NTPClient {
     int           _port           = NTP_DEFAULT_LOCAL_PORT;
     int           _timeOffset     = 0;
 
-    unsigned int  _updateInterval = 60000;  // In ms
+    unsigned long _updateInterval = 60000;  // In ms
 
     unsigned long _currentEpoc    = 0;      // In s
     unsigned long _lastUpdate     = 0;      // In ms
@@ -32,7 +32,7 @@ class NTPClient {
     NTPClient(UDP& udp, int timeOffset);
     NTPClient(UDP& udp, const char* poolServerName);
     NTPClient(UDP& udp, const char* poolServerName, int timeOffset);
-    NTPClient(UDP& udp, const char* poolServerName, int timeOffset, int updateInterval);
+    NTPClient(UDP& udp, const char* poolServerName, int timeOffset, unsigned long updateInterval);
 
     /**
      * Starts the underlying UDP client with the default local port
@@ -73,7 +73,7 @@ class NTPClient {
      * Set the update interval to another frequency. E.g. useful when the
      * timeOffset should not be set in the constructor
      */
-    void setUpdateInterval(int updateInterval);
+    void setUpdateInterval(unsigned long updateInterval);
 
     /**
      * @return time formatted like `hh:mm:ss`

--- a/NTPClient.h
+++ b/NTPClient.h
@@ -16,7 +16,6 @@ class NTPClient {
     bool          _udpSetup       = false;
 
     const char*   _poolServerName = "pool.ntp.org"; // Default time server
-    IPAddress     _poolServerIP;
     int           _port           = NTP_DEFAULT_LOCAL_PORT;
     int           _timeOffset     = 0;
 
@@ -33,14 +32,9 @@ class NTPClient {
   public:
     NTPClient(UDP& udp);
     NTPClient(UDP& udp, int timeOffset);
-    NTPClient(UDP& udp, const char* poolServerName);  
+    NTPClient(UDP& udp, const char* poolServerName);
     NTPClient(UDP& udp, const char* poolServerName, int timeOffset);
     NTPClient(UDP& udp, const char* poolServerName, int timeOffset, unsigned long updateInterval);
-    
-    
-    NTPClient(UDP& udp, IPAddress poolServerIP);
-    NTPClient(UDP& udp, IPAddress poolServerIP,int timeOffset);
-    NTPClient(UDP& udp, IPAddress poolServerIP, int timeOffset, unsigned long updateInterval);
 
     /**
      * Starts the underlying UDP client with the default local port

--- a/NTPClient.h
+++ b/NTPClient.h
@@ -7,6 +7,8 @@
 #define SEVENZYYEARS 2208988800UL
 #define NTP_PACKET_SIZE 48
 #define NTP_DEFAULT_LOCAL_PORT 1337
+#define LEAP_YEAR(Y)     ( (Y>0) && !(Y%4) && ( (Y%100) || !(Y%400) ) )
+
 
 class NTPClient {
   private:

--- a/NTPClient.h
+++ b/NTPClient.h
@@ -16,6 +16,7 @@ class NTPClient {
     bool          _udpSetup       = false;
 
     const char*   _poolServerName = "pool.ntp.org"; // Default time server
+    IPAddress     _poolServerIP;
     int           _port           = NTP_DEFAULT_LOCAL_PORT;
     int           _timeOffset     = 0;
 
@@ -32,9 +33,14 @@ class NTPClient {
   public:
     NTPClient(UDP& udp);
     NTPClient(UDP& udp, int timeOffset);
-    NTPClient(UDP& udp, const char* poolServerName);
+    NTPClient(UDP& udp, const char* poolServerName);  
     NTPClient(UDP& udp, const char* poolServerName, int timeOffset);
     NTPClient(UDP& udp, const char* poolServerName, int timeOffset, unsigned long updateInterval);
+    
+    
+    NTPClient(UDP& udp, IPAddress poolServerIP);
+    NTPClient(UDP& udp, IPAddress poolServerIP,int timeOffset);
+    NTPClient(UDP& udp, IPAddress poolServerIP, int timeOffset, unsigned long updateInterval);
 
     /**
      * Starts the underlying UDP client with the default local port

--- a/NTPClient.h
+++ b/NTPClient.h
@@ -25,6 +25,7 @@ class NTPClient {
     byte          _packetBuffer[NTP_PACKET_SIZE];
 
     void          sendNTPPacket();
+    bool          isValid(byte * ntpPacket);
 
   public:
     NTPClient(UDP& udp);

--- a/NTPClient.h
+++ b/NTPClient.h
@@ -76,9 +76,9 @@ class NTPClient {
     void setUpdateInterval(unsigned long updateInterval);
 
     /**
-     * @return time formatted like `hh:mm:ss`
-     */
-    String getFormattedTime();
+    * @return secs argument (or 0 for current time) formatted like `hh:mm:ss`
+    */
+    String getFormattedTime(unsigned long secs = 0);
 
     /**
      * @return time in seconds since Jan. 1, 1970
@@ -89,4 +89,9 @@ class NTPClient {
      * Stops the underlying UDP client
      */
     void end();
+
+    /**
+    * Replace the NTP-fetched time with seconds since Jan. 1, 1970
+    */
+    void setEpochTime(unsigned long secs);
 };

--- a/NTPClient.h
+++ b/NTPClient.h
@@ -13,7 +13,7 @@ class NTPClient {
     UDP*          _udp;
     bool          _udpSetup       = false;
 
-    const char*   _poolServerName = "time.nist.gov"; // Default time server
+    const char*   _poolServerName = "pool.ntp.org"; // Default time server
     int           _port           = NTP_DEFAULT_LOCAL_PORT;
     int           _timeOffset     = 0;
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ const char *password = "<PASSWORD>";
 
 WiFiUDP ntpUDP;
 
-// By default 'time.nist.gov' is used with 60 seconds update interval and
+// By default 'pool.ntp.org' is used with 60 seconds update interval and
 // no offset
 NTPClient timeClient(ntpUDP);
 


### PR DESCRIPTION
New function to change set new poolServerName

Example Code:
timeClient.setNewNTPServer("a.st1.ntp.br");
timeClient.begin();
timeClient.update();

Includes:
NTPClient.h
`void setNewNTPServer(const char* poolServerName);  `

NTPClient.cpp
```
void NTPClient::setNewNTPServer(const char* poolServerName){
this->_poolServerName = poolServerName;
}
```

