### PR TITLE
Make getter methods const

### DIFF
--- a/NTPClient.cpp
+++ b/NTPClient.cpp
@@ -101,26 +101,26 @@ bool NTPClient::update() {
   return true;
 }
 
-unsigned long NTPClient::getEpochTime() {
+unsigned long NTPClient::getEpochTime() const {
   return this->_timeOffset + // User offset
          this->_currentEpoc + // Epoc returned by the NTP server
          ((millis() - this->_lastUpdate) / 1000); // Time since last update
 }
 
-int NTPClient::getDay() {
+int NTPClient::getDay() const {
   return (((this->getEpochTime()  / 86400L) + 4 ) % 7); //0 is Sunday
 }
-int NTPClient::getHours() {
+int NTPClient::getHours() const {
   return ((this->getEpochTime()  % 86400L) / 3600);
 }
-int NTPClient::getMinutes() {
+int NTPClient::getMinutes() const {
   return ((this->getEpochTime() % 3600) / 60);
 }
-int NTPClient::getSeconds() {
+int NTPClient::getSeconds() const {
   return (this->getEpochTime() % 60);
 }
 
-String NTPClient::getFormattedTime() {
+String NTPClient::getFormattedTime() const {
   unsigned long rawTime = this->getEpochTime();
   unsigned long hours = (rawTime % 86400L) / 3600;
   String hoursStr = hours < 10 ? "0" + String(hours) : String(hours);

--- a/NTPClient.h
+++ b/NTPClient.h
@@ -58,10 +58,10 @@ class NTPClient {
      */
     bool forceUpdate();
 
-    int getDay();
-    int getHours();
-    int getMinutes();
-    int getSeconds();
+    int getDay() const;
+    int getHours() const;
+    int getMinutes() const;
+    int getSeconds() const;
 
     /**
      * Changes the time offset. Useful for changing timezones dynamically
@@ -77,12 +77,12 @@ class NTPClient {
     /**
      * @return time formatted like `hh:mm:ss`
      */
-    String getFormattedTime();
+    String getFormattedTime() const;
 
     /**
      * @return time in seconds since Jan. 1, 1970
      */
-    unsigned long getEpochTime();
+    unsigned long getEpochTime() const;
 
     /**
      * Stops the underlying UDP client


### PR DESCRIPTION
Hi,

With my change I'd like to make the getter methods in NTPClient const to make them usable in a const-correct environment. After inspecting the code base I'm pretty sure this won't break compatibility since all methods return results by value.