### PR TITLE
Added packet flush before request in forceUpdate(). Fixes issue #49 - random clock delay

### DIFF
--- a/NTPClient.cpp
+++ b/NTPClient.cpp
@@ -65,6 +65,10 @@ bool NTPClient::forceUpdate() {
     Serial.println("Update from NTP Server");
   #endif
 
+  // flush any existing packets
+  while(this->_udp->parsePacket() != 0)
+    this->_udp->flush();
+
   this->sendNTPPacket();
 
   // Wait till data is there or timeout...


### PR DESCRIPTION
This fixes issue #49 where the clock is randomly delayed.

The bug is that a response that comes back after the timeout delay is held in the receive buffer until the next update request.  That update sends a new request, but processes the OLD request sitting in the buffer. This cycle repeats indefinitely as each new request places a response in the buffer that will be consumed on the NEXT update cycle.

This can easily be verified / recreated by making the sendNTPPacket method public and calling it immediately after a call to update. Then wait for some time (a few seconds or several minutes, depending on the update interval) and then make another request to update (or forceUpdate). The newly updated time will be the OLD time from the response to the extra sendNTPPacket.  All subsequent requests will be off by one update interval unless and until a response packet is actually not sent.

The fix is to flush any queued responses before sending the new request. This is what the pull request accomplishes.
