### PR TITLE
Add event hooks when NTP update is started and complete.

### DIFF
--- a/NTPClient.cpp
+++ b/NTPClient.cpp
@@ -21,27 +21,42 @@
 
 #include "NTPClient.h"
 
-NTPClient::NTPClient(UDP& udp) {
+NTPClient::NTPClient(UDP& udp) 
+  :_updateStartHandler(NULL),
+   _updateEndHandler(NULL)
+{
   this->_udp            = &udp;
 }
 
-NTPClient::NTPClient(UDP& udp, long timeOffset) {
+NTPClient::NTPClient(UDP& udp, long timeOffset) 
+  :_updateStartHandler(NULL),
+   _updateEndHandler(NULL)
+{
   this->_udp            = &udp;
   this->_timeOffset     = timeOffset;
 }
 
-NTPClient::NTPClient(UDP& udp, const char* poolServerName) {
+NTPClient::NTPClient(UDP& udp, const char* poolServerName) 
+  :_updateStartHandler(NULL),
+   _updateEndHandler(NULL)
+{
   this->_udp            = &udp;
   this->_poolServerName = poolServerName;
 }
 
-NTPClient::NTPClient(UDP& udp, const char* poolServerName, long timeOffset) {
+NTPClient::NTPClient(UDP& udp, const char* poolServerName, long timeOffset) 
+  :_updateStartHandler(NULL),
+   _updateEndHandler(NULL)
+{
   this->_udp            = &udp;
   this->_timeOffset     = timeOffset;
   this->_poolServerName = poolServerName;
 }
 
-NTPClient::NTPClient(UDP& udp, const char* poolServerName, long timeOffset, unsigned long updateInterval) {
+NTPClient::NTPClient(UDP& udp, const char* poolServerName, long timeOffset, unsigned long updateInterval) 
+  :_updateStartHandler(NULL),
+   _updateEndHandler(NULL)
+{
   this->_udp            = &udp;
   this->_timeOffset     = timeOffset;
   this->_poolServerName = poolServerName;
@@ -65,6 +80,10 @@ bool NTPClient::forceUpdate() {
     Serial.println("Update from NTP Server");
   #endif
 
+  if (this->_updateStartHandler) {
+    this->_updateStartHandler();
+  }
+  
   this->sendNTPPacket();
 
   // Wait till data is there or timeout...
@@ -88,6 +107,10 @@ bool NTPClient::forceUpdate() {
   unsigned long secsSince1900 = highWord << 16 | lowWord;
 
   this->_currentEpoc = secsSince1900 - SEVENZYYEARS;
+
+  if (this->_updateEndHandler) {
+    this->_updateEndHandler();
+  }
 
   return true;
 }

--- a/NTPClient.h
+++ b/NTPClient.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <functional>
+
 #include "Arduino.h"
 
 #include <Udp.h>
@@ -9,6 +11,10 @@
 #define NTP_DEFAULT_LOCAL_PORT 1337
 
 class NTPClient {
+
+  public:
+    typedef std::function<void(void)> HandlerFunction;
+
   private:
     UDP*          _udp;
     bool          _udpSetup       = false;
@@ -23,6 +29,9 @@ class NTPClient {
     unsigned long _lastUpdate     = 0;      // In ms
 
     byte          _packetBuffer[NTP_PACKET_SIZE];
+
+    HandlerFunction _updateStartHandler;
+    HandlerFunction _updateEndHandler;
 
     void          sendNTPPacket();
 
@@ -95,4 +104,24 @@ class NTPClient {
      * Stops the underlying UDP client
      */
     void end();
+
+    /**
+     * 
+     */
+    inline void onStartUpdate (HandlerFunction);
+
+    /**
+     * 
+     */
+    inline void onEndUpdate (HandlerFunction);
 };
+
+inline void
+NTPClient::onStartUpdate (NTPClient::HandlerFunction handler) {
+  _updateStartHandler = handler;
+}
+
+inline void
+NTPClient::onEndUpdate (NTPClient::HandlerFunction handler) {
+  _updateEndHandler = handler;
+}


### PR DESCRIPTION
Hello,

I thought it would be useful and consistent with other Arduino libraries to allow triggering some actions when actual NTP conversation starts and ends.

In my case this API greatly simplifies showing NTP conversation status on my device. NTPClient::update() method is called each time in loop(), but only once per specified period actual NTP conversation is started under the hood.