### PR TITLE
added method to test if time was set correctly

### DIFF
--- a/NTPClient.cpp
+++ b/NTPClient.cpp
@@ -101,6 +101,10 @@ bool NTPClient::update() {
   return true;
 }
 
+bool NTPClient::isTimeSet() const {
+  return (this->_lastUpdate != 0); // returns true if the time has been set, else false
+}
+
 unsigned long NTPClient::getEpochTime() const {
   return this->_timeOffset + // User offset
          this->_currentEpoc + // Epoc returned by the NTP server

--- a/NTPClient.h
+++ b/NTPClient.h
@@ -65,6 +65,13 @@ class NTPClient {
      */
     bool forceUpdate();
 
+    /**
+     * This allows to check if the NTPClient successfully received a NTP packet and set the time.
+     *
+     * @return true if time has been set, else false
+     */
+    bool isTimeSet() const;
+
     int getDay() const;
     int getHours() const;
     int getMinutes() const;

--- a/examples/IsTimeSet/IsTimeSet.ino
+++ b/examples/IsTimeSet/IsTimeSet.ino
@@ -14,7 +14,7 @@ NTPClient timeClient(ntpUDP,"pool.ntp.org", 36000, 60000);
 //                           HH:MM:SS
 // timeClient initializes to 10:00:00 if it does not receive an NTP packet
 // before the 100ms timeout.
-// Without isTimeSet() the LED would be switched on, although the time
+// without isTimeSet() the LED would be switched on, although the time
 // was not yet set correctly.
 
 // blue led on ESP12F

--- a/examples/IsTimeSet/IsTimeSet.ino
+++ b/examples/IsTimeSet/IsTimeSet.ino
@@ -1,0 +1,53 @@
+#include <NTPClient.h>
+// change next line to use with another board/shield
+#include <ESP8266WiFi.h>
+//#include <WiFi.h> // for WiFi shield
+//#include <WiFi101.h> // for WiFi 101 shield or MKR1000
+#include <WiFiUdp.h>
+
+const char *ssid     = "<SSID>";
+const char *password = "<PASSWORD>";
+
+WiFiUDP ntpUDP;
+// initialized to a time offset of 10 hours
+NTPClient timeClient(ntpUDP,"pool.ntp.org", 36000,);
+//                           HH:MM:SS
+// timeClient initializes to 10:00:00 if it does not receive an NTP packet
+// before the 100ms timeout.
+// Without isTimeSet() the LED would be switched on, although the time
+// was not yet set correctly.
+
+// blue led on ESP12F
+const int led = 2;
+const int hour = 10;
+const int minute = 0;
+
+void setup(){
+  Serial.begin(115200);
+
+  pinMode(led, OUTPUT);
+  // led is off when pin is high
+  digitalWrite(led, 1);
+
+  WiFi.begin(ssid, password);
+
+  while ( WiFi.status() != WL_CONNECTED ) {
+    delay ( 500 );
+    Serial.print ( "." );
+  }
+
+  timeClient.begin();
+}
+
+void loop() {
+  timeClient.update();
+
+  Serial.println(timeClient.getFormattedTime());
+  if(timeClient.isTimeSet()) {
+    if (hour == timeClient.getHours() && minute == timeClient.getMinutes()) {
+      digitalWrite(led, 0);
+    }
+  }
+
+  delay(1000);
+}

--- a/examples/IsTimeSet/IsTimeSet.ino
+++ b/examples/IsTimeSet/IsTimeSet.ino
@@ -31,7 +31,7 @@ void setup(){
 
   WiFi.begin(ssid, password);
 
-  while ( WiFi.status() != WL_CONNECTED ) {
+  while (WiFi.status() != WL_CONNECTED) {
     delay (500);
     Serial.print (".");
   }

--- a/examples/IsTimeSet/IsTimeSet.ino
+++ b/examples/IsTimeSet/IsTimeSet.ino
@@ -32,7 +32,7 @@ void setup(){
   WiFi.begin(ssid, password);
 
   while ( WiFi.status() != WL_CONNECTED ) {
-    delay ( 500 );
+    delay (500);
     Serial.print ( "." );
   }
 

--- a/examples/IsTimeSet/IsTimeSet.ino
+++ b/examples/IsTimeSet/IsTimeSet.ino
@@ -33,7 +33,7 @@ void setup(){
 
   while ( WiFi.status() != WL_CONNECTED ) {
     delay (500);
-    Serial.print ( "." );
+    Serial.print (".");
   }
 
   timeClient.begin();

--- a/examples/IsTimeSet/IsTimeSet.ino
+++ b/examples/IsTimeSet/IsTimeSet.ino
@@ -10,7 +10,7 @@ const char *password = "<PASSWORD>";
 
 WiFiUDP ntpUDP;
 // initialized to a time offset of 10 hours
-NTPClient timeClient(ntpUDP,"pool.ntp.org", 36000,);
+NTPClient timeClient(ntpUDP,"pool.ntp.org", 36000, 60000);
 //                           HH:MM:SS
 // timeClient initializes to 10:00:00 if it does not receive an NTP packet
 // before the 100ms timeout.

--- a/examples/IsTimeSet/IsTimeSet.ino
+++ b/examples/IsTimeSet/IsTimeSet.ino
@@ -17,7 +17,7 @@ NTPClient timeClient(ntpUDP,"pool.ntp.org", 36000, 60000);
 // without isTimeSet() the LED would be switched on, although the time
 // was not yet set correctly.
 
-// blue led on ESP12F
+// blue LED on ESP-12F
 const int led = 2;
 const int hour = 10;
 const int minute = 0;

--- a/keywords.txt
+++ b/keywords.txt
@@ -12,7 +12,7 @@ begin	KEYWORD2
 end	KEYWORD2
 update	KEYWORD2
 forceUpdate	KEYWORD2
-isTimeSet KEYWORD2
+isTimeSet	KEYWORD2
 getDay	KEYWORD2
 getHours	KEYWORD2
 getMinutes	KEYWORD2

--- a/keywords.txt
+++ b/keywords.txt
@@ -12,6 +12,7 @@ begin	KEYWORD2
 end	KEYWORD2
 update	KEYWORD2
 forceUpdate	KEYWORD2
+isTimeSet KEYWORD2
 getDay	KEYWORD2
 getHours	KEYWORD2
 getMinutes	KEYWORD2


### PR DESCRIPTION
Allows the user to test if the NTPClient has set the time correctly.
Useful for calculations where false positives are not acceptable.
I also added a new example to present a very simple usecase for this.