### PR TITLE
Re-works the update() method to avoid blocking

### DIFF
--- a/NTPClient.h
+++ b/NTPClient.h
@@ -23,6 +23,9 @@ class NTPClient {
     unsigned long _currentEpoc    = 0;      // In s
     unsigned long _lastUpdate     = 0;      // In ms
 
+    unsigned long _requestSent    = 0;      // in ms (when the last request was sent)
+    unsigned long _requestDelay   = 1;      // in ms (a cumulative delay to slow down constant failures)
+
     byte          _packetBuffer[NTP_PACKET_SIZE];
 
     void          sendNTPPacket();


### PR DESCRIPTION
I was seeing weird issues following an unrelated failed OTA update where the NTP update() call would block the `loop()` method for 1024ms whilst packets timed out despite seeing replies going back to the ESP.

This PR tweaks the `update()` method to work asynchronously rather than blocking things to implement the timeout which sorted things out for me.

In addition, it also adds a backoff to timeout so we don't end up in a state constantly hammering the NTP server.

I'm using these changes in my project and, if you think they'll be generally useful, you're welcome to them under the same MIT license as the original work.

Cheers.