### PR TITLE
Added method to set random local port

### DIFF
--- a/NTPClient.cpp
+++ b/NTPClient.cpp
@@ -73,7 +73,7 @@ void NTPClient::begin() {
   this->begin(NTP_DEFAULT_LOCAL_PORT);
 }
 
-void NTPClient::begin(int port) {
+void NTPClient::begin(long port) {
   this->_port = port;
 
   this->_udp->begin(this->_port);
@@ -120,7 +120,7 @@ bool NTPClient::forceUpdate() {
 bool NTPClient::update() {
   if ((millis() - this->_lastUpdate >= this->_updateInterval)     // Update after _updateInterval
     || this->_lastUpdate == 0) {                                // Update if there was no update yet.
-    if (!this->_udpSetup) this->begin();                         // setup the UDP client if needed
+    if (!this->_udpSetup || this->_port != NTP_DEFAULT_LOCAL_PORT) this->begin(this->_port); // setup the UDP client if needed
     return this->forceUpdate();
   }
   return false;   // return false if update does not occur
@@ -181,7 +181,8 @@ void NTPClient::sendNTPPacket() {
   // set all bytes in the buffer to 0
   memset(this->_packetBuffer, 0, NTP_PACKET_SIZE);
   // Initialize values needed to form NTP request
-  // (see URL above for details on the packets)
+  // (see URL above for details on the packets)  Serial.println(this->_port);
+
   this->_packetBuffer[0] = 0b11100011;   // LI, Version, Mode
   this->_packetBuffer[1] = 0;     // Stratum, or type of clock
   this->_packetBuffer[2] = 6;     // Polling Interval
@@ -201,4 +202,9 @@ void NTPClient::sendNTPPacket() {
   }
   this->_udp->write(this->_packetBuffer, NTP_PACKET_SIZE);
   this->_udp->endPacket();
+}
+
+void NTPClient::setRandomPort() {
+  randomSeed(analogRead(0));
+  this->_port = random(1, 65534);
 }

--- a/NTPClient.cpp
+++ b/NTPClient.cpp
@@ -73,7 +73,7 @@ void NTPClient::begin() {
   this->begin(NTP_DEFAULT_LOCAL_PORT);
 }
 
-void NTPClient::begin(long port) {
+void NTPClient::begin(unsigned int port) {
   this->_port = port;
 
   this->_udp->begin(this->_port);
@@ -181,7 +181,7 @@ void NTPClient::sendNTPPacket() {
   // set all bytes in the buffer to 0
   memset(this->_packetBuffer, 0, NTP_PACKET_SIZE);
   // Initialize values needed to form NTP request
-  // (see URL above for details on the packets)  Serial.println(this->_port);
+  // (see URL above for details on the packets)
 
   this->_packetBuffer[0] = 0b11100011;   // LI, Version, Mode
   this->_packetBuffer[1] = 0;     // Stratum, or type of clock
@@ -204,7 +204,7 @@ void NTPClient::sendNTPPacket() {
   this->_udp->endPacket();
 }
 
-void NTPClient::setRandomPort(long minValue, long maxValue) {
+void NTPClient::setRandomPort(unsigned int minValue, unsigned int maxValue) {
   randomSeed(analogRead(0));
   this->_port = random(minValue, maxValue);
 }

--- a/NTPClient.cpp
+++ b/NTPClient.cpp
@@ -204,7 +204,7 @@ void NTPClient::sendNTPPacket() {
   this->_udp->endPacket();
 }
 
-void NTPClient::setRandomPort() {
+void NTPClient::setRandomPort(long minValue, long maxValue) {
   randomSeed(analogRead(0));
-  this->_port = random(1, 65534);
+  this->_port = random(minValue, maxValue);
 }

--- a/NTPClient.h
+++ b/NTPClient.h
@@ -47,7 +47,7 @@ class NTPClient {
      /**
      * Set random local port
      */
-    void setRandomPort();
+    void setRandomPort(long minValue, long maxValue);
 
     /**
      * Starts the underlying UDP client with the default local port

--- a/NTPClient.h
+++ b/NTPClient.h
@@ -15,7 +15,7 @@ class NTPClient {
 
     const char*   _poolServerName = "pool.ntp.org"; // Default time server
     IPAddress     _poolServerIP;
-    int           _port           = NTP_DEFAULT_LOCAL_PORT;
+    long           _port           = NTP_DEFAULT_LOCAL_PORT;
     long          _timeOffset     = 0;
 
     unsigned long _updateInterval = 60000;  // In ms
@@ -44,6 +44,11 @@ class NTPClient {
      */
     void setPoolServerName(const char* poolServerName);
 
+     /**
+     * Set random local port
+     */
+    void setRandomPort();
+
     /**
      * Starts the underlying UDP client with the default local port
      */
@@ -52,7 +57,7 @@ class NTPClient {
     /**
      * Starts the underlying UDP client with the specified local port
      */
-    void begin(int port);
+    void begin(long port);
 
     /**
      * This should be called in the main loop of your application. By default an update from the NTP Server is only

--- a/NTPClient.h
+++ b/NTPClient.h
@@ -15,7 +15,7 @@ class NTPClient {
 
     const char*   _poolServerName = "pool.ntp.org"; // Default time server
     IPAddress     _poolServerIP;
-    long           _port           = NTP_DEFAULT_LOCAL_PORT;
+    unsigned int  _port           = NTP_DEFAULT_LOCAL_PORT;
     long          _timeOffset     = 0;
 
     unsigned long _updateInterval = 60000;  // In ms
@@ -47,7 +47,7 @@ class NTPClient {
      /**
      * Set random local port
      */
-    void setRandomPort(long minValue, long maxValue);
+    void setRandomPort(unsigned int minValue, unsigned int maxValue);
 
     /**
      * Starts the underlying UDP client with the default local port
@@ -57,7 +57,7 @@ class NTPClient {
     /**
      * Starts the underlying UDP client with the specified local port
      */
-    void begin(long port);
+    void begin(unsigned int port);
 
     /**
      * This should be called in the main loop of your application. By default an update from the NTP Server is only


### PR DESCRIPTION
> _Added method to set a (pseudo)random local port, so that the board needs not to use always the same embedded local port for receiving NTP packets._

At the moment, the variable `port` is a constant embedded value used by the board for receiving NTP packets via unencrypted UDP connection. Changing randomly port to receive NTP packets doesn't improve cryptographic security and it is not the final solution, but it adds a layer to make harder the attacker's job. 

## How to use

```
void setup() {
  ...
}
void loop() {
  timeClient.setRandomPort();
  timeClient.update();
}
```

## How it works

`setRandomPort()` sets a pseudorandom port and `NTPClient::update()` launches `NTPClient.begin(port)` if `port` is different by default value `NTP_DEFAULT_LOCAL_PORT`