### PR TITLE
Remove erroneous comment re: packets

### DIFF
--- a/NTPClient.cpp
+++ b/NTPClient.cpp
@@ -181,8 +181,6 @@ void NTPClient::sendNTPPacket() {
   // set all bytes in the buffer to 0
   memset(this->_packetBuffer, 0, NTP_PACKET_SIZE);
   // Initialize values needed to form NTP request
-  // (see URL above for details on the packets)
-
   this->_packetBuffer[0] = 0b11100011;   // LI, Version, Mode
   this->_packetBuffer[1] = 0;     // Stratum, or type of clock
   this->_packetBuffer[2] = 6;     // Polling Interval


### PR DESCRIPTION
The comment directs the reader to find a URL "above" for more information, but there is no such URL anywhere in the source code, and never was even when the comment was introduced to the repository on the first commit.

Closes https://github.com/arduino-libraries/NTPClient/issues/143