### PR TITLE
Add FreeRTOS support for multi-thread applications on ESP32

### DIFF
--- a/NTPClient.cpp
+++ b/NTPClient.cpp
@@ -96,7 +96,13 @@ bool NTPClient::forceUpdate() {
   byte timeout = 0;
   int cb = 0;
   do {
+
+#if defined(ESP32) || defined(ESP8266)
+    vTaskDelay(pdMS_TO_TICKS(10));
+#else
     delay ( 10 );
+#endif
+
     cb = this->_udp->parsePacket();
     if (timeout > 100) return false; // timeout after 1000 ms
     timeout++;

--- a/NTPClient.h
+++ b/NTPClient.h
@@ -4,6 +4,10 @@
 
 #include <Udp.h>
 
+#if defined(ESP32) || defined(ESP8266)
+#include "freertos/FreeRTOS.h"
+#endif
+
 #define SEVENZYYEARS 2208988800UL
 #define NTP_PACKET_SIZE 48
 #define NTP_DEFAULT_LOCAL_PORT 1337


### PR DESCRIPTION
When writing multi-threaded code with FreeRTOS on ESP32 and ESP8266, usage of ```delay``` function locks RTOS scheduler, so it is more correct to use ```vTaskDelay```, which is done in this PR.