### PR TITLE
Added getFormattedDateTime method

### DIFF
--- a/NTPClient.h
+++ b/NTPClient.h
@@ -8,9 +8,17 @@
 #define NTP_PACKET_SIZE 48
 #define NTP_DEFAULT_LOCAL_PORT 1337
 
+struct DateLanguageData {
+    const char* shortWeekDays[7];
+    const char* longWeekDays[7];
+    const char* shortMonths[12];
+    const char* longMonths[12];
+};
+
 class NTPClient {
   private:
     UDP*          _udp;
+    String        _dateLanguage   = "en"; // Default language
     bool          _udpSetup       = false;
 
     const char*   _poolServerName = "pool.ntp.org"; // Default time server
@@ -81,7 +89,10 @@ class NTPClient {
      */
     bool isTimeSet() const;
 
+    int getDayOfWeek() const;
     int getDay() const;
+    int getMonth() const;
+    int getYear() const;
     int getHours() const;
     int getMinutes() const;
     int getSeconds() const;
@@ -98,9 +109,28 @@ class NTPClient {
     void setUpdateInterval(unsigned long updateInterval);
 
     /**
-     * @return time formatted like `hh:mm:ss`
+     * @return Date Time string formated. The available format codes are:
+      %Y: Full year (e.g., 2023)
+      %y: Last two digits of the year (e.g., 23 for 2023)
+      %m: Month as a zero-padded decimal number (01 to 12)
+      %d: Day of the month as a zero-padded decimal number (01 to 31)
+      %H: Hour (00 to 23) as a zero-padded decimal number
+      %M: Minute as a zero-padded decimal number (00 to 59)
+      %S: Second as a zero-padded decimal number (00 to 59)
+      %a: Abbreviated weekday name according to the current locale
+      %A: Full weekday name according to the current locale
+      %w: Weekday as a decimal number (0 for Sunday through 6 for Saturday)
+      %b: Abbreviated month name according to the current locale
+      %B: Full month name according to the current locale
+      %p: "AM" or "PM" based on the hour (Note: This is locale-sensitive and might not be applicable in all languages)
      */
-    String getFormattedTime() const;
+    String getFormattedDateTime(const String &format);
+
+     /**
+     * Set language for displaying date. Available languages are 'pt', 'es' and 'en' (default)
+     * @param dateLanguage
+     */
+    void setDateLanguage(const String &dateLanguage);
 
     /**
      * @return time in seconds since Jan. 1, 1970

--- a/keywords.txt
+++ b/keywords.txt
@@ -14,10 +14,14 @@ update	KEYWORD2
 forceUpdate	KEYWORD2
 isTimeSet	KEYWORD2
 getDay	KEYWORD2
+getDayOfWeek KEYWORD2
+getDay KEYWORD2
+getMonth KEYWORD2
+getYear KEYWORD2
 getHours	KEYWORD2
 getMinutes	KEYWORD2
 getSeconds	KEYWORD2
-getFormattedTime	KEYWORD2
+getFormattedDateTime	KEYWORD2
 getEpochTime	KEYWORD2
 setTimeOffset	KEYWORD2
 setUpdateInterval	KEYWORD2


### PR DESCRIPTION
Implement getFormattedDateTime, which has the advantage, when compared #94 that does not rely on external lib and parse more patterns:

```
  %Y: Full year (e.g., 2023)
  %y: Last two digits of the year (e.g., 23 for 2023)
  %m: Month as a zero-padded decimal number (01 to 12)
  %d: Day of the month as a zero-padded decimal number (01 to 31)
  %H: Hour (00 to 23) as a zero-padded decimal number
  %M: Minute as a zero-padded decimal number (00 to 59)
  %S: Second as a zero-padded decimal number (00 to 59)
  %a: Abbreviated weekday name according to the current locale
  %A: Full weekday name according to the current locale
  %w: Weekday as a decimal number (0 for Sunday through 6 for Saturday)
  %b: Abbreviated month name according to the current locale
  %B: Full month name according to the current locale
  %p: "AM" or "PM" based on the hour (Note: This is locale-sensitive and might not be applicable in all languages)
```

The #161 was used as base, however, I had to change all the calculation logic, as the results were not correct