### PR TITLE
Use standardized `maintainer` metadata property value

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -1,7 +1,7 @@
 name=NTPClient
 version=3.2.1
 author=Fabrice Weinberg
-maintainer=Fabrice Weinberg <fabrice@weinberg.me>
+maintainer=Arduino <info@arduino.cc>
 sentence=An NTPClient to connect to a time server
 paragraph=Get time from a NTP server and keep it in sync.
 category=Timing


### PR DESCRIPTION
The `maintainer` property of the [`library.properties` metadata file](https://arduino.github.io/arduino-cli/latest/library-specification/#library-metadata) defines the entity responsible for maintenance of the library.

In the libraries that are under Arduino's maintainership, it is standard practice to set the `maintainer` property to the general purpose value "Arduino <info@arduino.cc>".

Previously, instead of that standard value, this library's `maintainer` property defined a specific developer as the maintainer. This is prone to "bit rot", as the scope of each individual's work may change over time. It is unlikely that an individual developer team member will remember to update the metadata values at such time as they are no longer able to dedicate themselves to maintaining the library. So the metadata is changed to use the standard value.